### PR TITLE
use standard Rails rendering

### DIFF
--- a/app/components/issues/badge.html.erb
+++ b/app/components/issues/badge.html.erb
@@ -1,3 +1,3 @@
-<%= render(Primer::State.new(color: STATES[state][:color], title: "Status: #{state.to_s.titleize}")) do %>
-  <%= octicon(STATES[state][:octicon_name]) %> <%= STATES[state][:label] %>
+<%= render Primer::State.new color: Issues::Badge::STATES[state][:color], title: "Status: #{state.to_s.titleize}" do %>
+  <%= octicon Issues::Badge::STATES[state][:octicon_name] %> <%= Issues::Badge::STATES[state][:label] %>
 <% end %>

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'delegate'
-
 module ActionView
   class Component < ActionView::Base
     include ActiveModel::Validations

--- a/config/initializers/component_paths.rb
+++ b/config/initializers/component_paths.rb
@@ -1,0 +1,3 @@
+ActiveSupport.on_load :action_controller do
+  append_view_path Rails.root.join("app", "components")
+end


### PR DESCRIPTION
An update of the `ActionView::Component` to use standard Rails template rendering.

This is still work in progress, the main issue at the moment is evaluating blocks in the proper context of the parent component. Help wanted.