### PR TITLE
Update monkey patch to allow rendering in controller actions

### DIFF
--- a/app/controllers/demo_controller.rb
+++ b/app/controllers/demo_controller.rb
@@ -1,4 +1,14 @@
 class DemoController < ApplicationController
   def index
   end
+
+  def show
+    Issue.all.each do |issue|
+      if issue.pull_request
+        render(PullRequests::Badge.new(state: issue.pull_request.state.to_sym, is_draft: issue.pull_request.draft?))
+      else
+        render(Issues::Badge.new(state: issue.state.to_sym))
+      end
+    end
+  end
 end

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -1,16 +1,25 @@
 # Use this monkey patch if you aren't running Rails master / 6.1 alpha
 #
-# class ActionView::Base
-#   module RenderMonkeyPatch
-#     def render(component, _ = nil, &block)
-#       return super unless component.respond_to?(:render_in)
+# module ViewComponentRenderer
+#   def render(component, _ = nil, &block)
+#     return super unless component.respond_to?(:render_in)
 #
-#       component.render_in(self, &block)
-#     end
+#     component.render_in(self, &block)
 #   end
-#
-#   prepend RenderMonkeyPatch
 # end
+#
+# module ControllerComponentRenderer
+#   def render(context, options, &block)
+#     return super unless options[:partial].respond_to?(:render_in)
+#
+#     options[:partial].render_in(self, &block)
+#   end
+# end
+#
+# # Used when calling `render` in templates and partials
+# ActionView::Base.prepend(ViewComponentRenderer)
+# # Used when calling `render` in controller actions
+# ActionView::Renderer.prepend(ControllerComponentRenderer)
 
 module ActionView
   class Component < ActionView::Base

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -8,18 +8,22 @@
 #   end
 # end
 #
-# module ControllerComponentRenderer
-#   def render(context, options, &block)
-#     return super unless options[:partial].respond_to?(:render_in)
-#
-#     options[:partial].render_in(self, &block)
-#   end
-# end
 #
 # # Used when calling `render` in templates and partials
 # ActionView::Base.prepend(ViewComponentRenderer)
+
+module ControllerComponentRenderer
+  def render(component, _ = nil)
+    return super unless component.respond_to?(:render_in)
+
+    self.response_body = component.render_in(self)
+
+    return
+  end
+end
+
 # # Used when calling `render` in controller actions
-# ActionView::Renderer.prepend(ControllerComponentRenderer)
+ActionController::Base.prepend(ControllerComponentRenderer)
 
 module ActionView
   class Component < ActionView::Base

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root to: "demo#index"
   get :benchmark, to: "demo#benchmark"
+  get :show, to: "demo#show"
 end

--- a/spec/controllers/demo_controller_spec.rb
+++ b/spec/controllers/demo_controller_spec.rb
@@ -3,73 +3,87 @@ require "rails_helper"
 RSpec.describe DemoController, type: :controller do
   render_views
 
-  it "renders the open issue badge" do
-    create(:issue, :open)
+  context "#index" do
+    it "renders the open issue badge" do
+      create(:issue, :open)
 
-    get :index
+      get :index
 
-    assert_select(".State.State--green")
-    assert_select(".octicon-issue-opened")
-    assert_includes(response.body, "Open")
+      assert_select(".State.State--green")
+      assert_select(".octicon-issue-opened")
+      assert_includes(response.body, "Open")
+    end
+
+    it "renders the closed issue badge" do
+      create(:issue, :closed)
+
+      get :index
+
+      assert_select(".State.State--red")
+      assert_select(".octicon-issue-closed")
+      assert_includes(response.body, "Closed")
+    end
+
+    it "renders the open pull request badge" do
+      create(:issue, :open, :with_pull_request)
+
+      get :index
+
+      assert_select(".State.State--green")
+      assert_select(".octicon-git-pull-request")
+      assert_includes(response.body, "Open")
+    end
+
+    it "renders the closed pull request badge" do
+      create(:issue, :closed, :with_pull_request)
+
+      get :index
+
+      assert_select(".State.State--red")
+      assert_select(".octicon-git-pull-request")
+      assert_includes(response.body, "Closed")
+    end
+
+    it "renders the merged pull request badge" do
+      create(:issue, :closed, pull_request: create(:pull_request, :merged))
+
+      get :index
+
+      assert_select(".State.State--purple")
+      assert_select(".octicon-git-merge")
+      assert_includes(response.body, "Merged")
+    end
+
+    it "renders the draft pull request badge" do
+      create(:issue, :open, pull_request: create(:pull_request, :draft))
+
+      get :index
+
+      assert_select(".State")
+      assert_select(".octicon-git-pull-request")
+      assert_includes(response.body, "Draft")
+    end
+
+    it "renders the closed pull request badge for a closed draft pull request" do
+      create(:issue, :closed, pull_request: create(:pull_request, :draft))
+
+      get :index
+
+      assert_select(".State.State--red")
+      assert_select(".octicon-git-pull-request")
+      assert_includes(response.body, "Closed")
+    end
   end
 
-  it "renders the closed issue badge" do
-    create(:issue, :closed)
+  context "#inline_render" do
+    it "renders the open issue badge" do
+      create(:issue, :open)
 
-    get :index
+      get :show
 
-    assert_select(".State.State--red")
-    assert_select(".octicon-issue-closed")
-    assert_includes(response.body, "Closed")
-  end
-
-  it "renders the open pull request badge" do
-    create(:issue, :open, :with_pull_request)
-
-    get :index
-
-    assert_select(".State.State--green")
-    assert_select(".octicon-git-pull-request")
-    assert_includes(response.body, "Open")
-  end
-
-  it "renders the closed pull request badge" do
-    create(:issue, :closed, :with_pull_request)
-
-    get :index
-
-    assert_select(".State.State--red")
-    assert_select(".octicon-git-pull-request")
-    assert_includes(response.body, "Closed")
-  end
-
-  it "renders the merged pull request badge" do
-    create(:issue, :closed, pull_request: create(:pull_request, :merged))
-
-    get :index
-
-    assert_select(".State.State--purple")
-    assert_select(".octicon-git-merge")
-    assert_includes(response.body, "Merged")
-  end
-
-  it "renders the draft pull request badge" do
-    create(:issue, :open, pull_request: create(:pull_request, :draft))
-
-    get :index
-
-    assert_select(".State")
-    assert_select(".octicon-git-pull-request")
-    assert_includes(response.body, "Draft")
-  end
-
-  it "renders the closed pull request badge for a closed draft pull request" do
-    create(:issue, :closed, pull_request: create(:pull_request, :draft))
-
-    get :index
-
-    assert_select(".State.State--red")
-    assert_select(".octicon-git-pull-request")
-    assert_includes(response.body, "Closed")
+      assert_select(".State.State--green")
+      assert_select(".octicon-issue-opened")
+      assert_includes(response.body, "Open")
+    end
   end
 end


### PR DESCRIPTION
I've been playing around with the component implementation along with the specified [monkey patch](https://github.com/joelhawksley/actionview-component-demo/blob/cfc599b52d7b8544cf0d13a7c4655f1c43e9163b/app/lib/action_view/component.rb#L4) on a Rails 5.1 project and it's been a wonderful experience so far 👏 

However, I noticed that it isn't possible to render a component directly from a controller action, like so:

```ruby
class DashboardController < ApplicationController
  def show
    render Widget.new
  end
end
```

I don't know if this is intentional or not? I glanced at the [PR on the Rails repository](https://github.com/rails/rails/pull/36388), but couldn't find any mentions of it.

I realize that its use would be limited since rendering components with a block probably wouldn't work very well inside a controller action, but I still think there could be real use cases for this. 

I've updated the monkey patch, if you want to add support for it. Let me know if something is unclear or needs to be changed 🙂 

Thank you so much for all of your work on this! Can't wait to see it in Rails 6.1 🍻 