### PR TITLE
Support arbitrary template renderers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem "bootsnap", ">= 1.1.0", require: false
 
 gem "benchmark-ips"
 
+gem "haml"
+gem "slim"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,9 @@ GEM
     ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    haml (5.1.1)
+      temple (>= 0.8.0)
+      tilt
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -217,6 +220,9 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    slim (4.0.1)
+      temple (>= 0.7.6, < 0.9)
+      tilt (>= 2.0.6, < 2.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -224,6 +230,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temple (0.8.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -258,6 +265,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails
   factory_bot_rails
+  haml
   jbuilder
   listen (>= 3.0.5, < 3.2)
   octicons_helper
@@ -270,6 +278,7 @@ DEPENDENCIES
   sassc-rails
   selenium-webdriver
   simplecov
+  slim
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/components/component_with_too_many_sidecar_files.html.erb
+++ b/app/components/component_with_too_many_sidecar_files.html.erb
@@ -1,0 +1,1 @@
+<div>hello, world!</div>

--- a/app/components/component_with_too_many_sidecar_files.html.slim
+++ b/app/components/component_with_too_many_sidecar_files.html.slim
@@ -1,0 +1,1 @@
+| hello, world!

--- a/app/components/component_with_too_many_sidecar_files.rb
+++ b/app/components/component_with_too_many_sidecar_files.rb
@@ -1,0 +1,4 @@
+class ComponentWithTooManySidecarFiles < ActionView::Component
+  def initialize(*)
+  end
+end

--- a/app/components/component_without_initializer.rb
+++ b/app/components/component_without_initializer.rb
@@ -1,0 +1,2 @@
+class ComponentWithoutInitializer < ActionView::Component
+end

--- a/app/components/component_without_template.rb
+++ b/app/components/component_without_template.rb
@@ -1,0 +1,4 @@
+class ComponentWithoutTemplate < ActionView::Component
+  def initialize(*)
+  end
+end

--- a/app/components/haml_template.html.haml
+++ b/app/components/haml_template.html.haml
@@ -1,0 +1,3 @@
+%div
+  = content
+  = @message

--- a/app/components/haml_template.rb
+++ b/app/components/haml_template.rb
@@ -1,0 +1,7 @@
+class HamlTemplate < ActionView::Component
+  validates :content, presence: true
+
+  def initialize(message:)
+    @message = message
+  end
+end

--- a/app/components/route.rb
+++ b/app/components/route.rb
@@ -1,0 +1,10 @@
+class Route < ActionView::Component
+  def initialize(*)
+  end
+
+  def self.template
+    <<-erb
+    <%= root_path %>
+    erb
+  end
+end

--- a/app/components/slim_template.html.slim
+++ b/app/components/slim_template.html.slim
@@ -1,0 +1,3 @@
+div
+  = content
+  = @message

--- a/app/components/slim_template.rb
+++ b/app/components/slim_template.rb
@@ -1,0 +1,7 @@
+class SlimTemplate < ActionView::Component
+  validates :content, presence: true
+
+  def initialize(message:)
+    @message = message
+  end
+end

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -86,10 +86,9 @@ module ActionView
       end
 
       def template_file_path
-        filename = self.instance_method(:initialize).source_location[0]
-
         raise NotImplementedError.new("#{self} must implement #initialize.") unless self.instance_method(:initialize).owner == self
 
+        filename = self.instance_method(:initialize).source_location[0]
         filename_without_extension = filename[0..-(File.extname(filename).length + 1)]
         siblings_files = Dir["#{filename_without_extension}.*"] - [filename]
 

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -98,17 +98,18 @@ module ActionView
       siblings_files = Dir["#{filename_without_extension}.*"] - [filename]
 
       raise StandardError.new("too many sidecars") if siblings_files.length > 1
-      raise StandardError.new("could not find sidecar file") if siblings_files.length == 0
+
+      if siblings_files.length == 0
+        raise NotImplementedError.new(
+          "Could not find a template for #{self}. Either define a .template method or add a sidecar template file."
+        )
+      end
 
       siblings_files[0]
     end
 
     def self.template
-      if File.file?(template_file_path)
-        File.read(template_file_path)
-      else
-        raise NotImplementedError.new("Could not find template")
-      end
+      File.read(template_file_path)
     end
 
     private

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -50,6 +50,12 @@ module ActionView
 
     def initialize(*); end
 
+    def self.inherited(child)
+      child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
+
+      super
+    end
+
     def self.compile
       @compiled ||= nil
       return if @compiled

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -97,7 +97,9 @@ module ActionView
       filename_without_extension = filename[0..-(File.extname(filename).length + 1)]
       siblings_files = Dir["#{filename_without_extension}.*"] - [filename]
 
-      raise StandardError.new("too many sidecars") if siblings_files.length > 1
+      if siblings_files.length > 1
+        raise StandardError.new("More than one template found for #{self}. There can only be one sidecar template file per component.")
+      end
 
       if siblings_files.length == 0
         raise NotImplementedError.new(

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -48,8 +48,6 @@ module ActionView
       call
     end
 
-    def initialize(*); end
-
     class << self
       def inherited(child)
         child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
@@ -88,7 +86,7 @@ module ActionView
       def template_file_path
         filename = self.instance_method(:initialize).source_location[0]
 
-        raise NotImplementedError.new("Subclasses of ActionView::Component must implement #initialize") if filename == __FILE__
+        raise NotImplementedError.new("#{self} must implement #initialize.") unless filename.include?(self.name.underscore)
 
         filename_without_extension = filename[0..-(File.extname(filename).length + 1)]
         siblings_files = Dir["#{filename_without_extension}.*"] - [filename]

--- a/app/lib/action_view/component.rb
+++ b/app/lib/action_view/component.rb
@@ -48,6 +48,8 @@ module ActionView
       call
     end
 
+    def initialize(*); end
+
     class << self
       def inherited(child)
         child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
@@ -86,7 +88,7 @@ module ActionView
       def template_file_path
         filename = self.instance_method(:initialize).source_location[0]
 
-        raise NotImplementedError.new("#{self} must implement #initialize.") unless filename.include?(self.name.underscore)
+        raise NotImplementedError.new("#{self} must implement #initialize.") unless self.instance_method(:initialize).owner == self
 
         filename_without_extension = filename[0..-(File.extname(filename).length + 1)]
         siblings_files = Dir["#{filename_without_extension}.*"] - [filename]

--- a/spec/components/box_spec.rb
+++ b/spec/components/box_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Box do
+  it "renders component with inline template" do
+    result = render_component(Box.new) { "foo" }
+
+    assert result.css(".Box").any?
+  end
+end

--- a/spec/components/component_with_too_many_sidecar_files_spec.rb
+++ b/spec/components/component_with_too_many_sidecar_files_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe ComponentWithTooManySidecarFiles do
+  it "responds with a friendly message if there is no template" do
+    error = assert_raises StandardError do
+      render_component(ComponentWithTooManySidecarFiles.new)
+    end
+
+    assert_includes error.message, "More than one template found for ComponentWithTooManySidecarFiles."
+  end
+end

--- a/spec/components/component_without_initializer_spec.rb
+++ b/spec/components/component_without_initializer_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe ComponentWithoutInitializer do
+  it "responds with a friendly message if there is no template" do
+    error = assert_raises NotImplementedError do
+      render_component(ComponentWithoutInitializer.new)
+    end
+
+    assert_includes error.message, "ComponentWithoutInitializer must implement #initialize."
+  end
+end

--- a/spec/components/component_without_template_spec.rb
+++ b/spec/components/component_without_template_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe ComponentWithoutTemplate do
+  it "responds with a friendly message if there is no template" do
+    error = assert_raises NotImplementedError do
+      render_component(ComponentWithoutTemplate.new)
+    end
+
+    assert_includes error.message, "Could not find a template for ComponentWithoutTemplate."
+  end
+end

--- a/spec/components/haml_template_spec.rb
+++ b/spec/components/haml_template_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe HamlTemplate do
+  it "renders component with content" do
+    result = render_component(HamlTemplate.new(message: "bar")) { "foo" }
+
+    assert_includes result.text, "foo"
+    assert_includes result.text, "bar"
+  end
+end

--- a/spec/components/route_spec.rb
+++ b/spec/components/route_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Route do
+  it "renders component with url helper" do
+    result = render_component(Route.new)
+
+    assert_includes result.text, "/"
+  end
+end

--- a/spec/components/slim_template_spec.rb
+++ b/spec/components/slim_template_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe SlimTemplate do
+  it "renders component with content" do
+    result = render_component(SlimTemplate.new(message: "bar")) { "foo" }
+
+    assert_includes result.text, "foo"
+    assert_includes result.text, "bar"
+  end
+end


### PR DESCRIPTION
After pairing with @tomasc on https://github.com/joelhawksley/actionview-component-demo/pull/12, I set out to see if it would be possible to support arbitrary template formats for sidecar files without using the existing Rails view path registration/retrieval architecture.

This PR is what @tenderlove and I came up with yesterday. It's not _perfect_ by any means, especially when it comes to our use of `DummyTemplate`, a stand-in for `ActionView::Template`, but generally this feels like the way to go at this point.

This PR also starts us down the journey of supporting the expected Rails view helpers out of the box, making URL helpers accessible within components.