### PR TITLE
Component with translations example

### DIFF
--- a/app/components/component_with_translations.html.erb
+++ b/app/components/component_with_translations.html.erb
@@ -1,0 +1,2 @@
+<h1><%= t('.title') %></h1>
+<h2><%= t('components.component_with_translations.subtitle') %></h2>

--- a/app/components/component_with_translations.rb
+++ b/app/components/component_with_translations.rb
@@ -1,0 +1,4 @@
+class ComponentWithTranslations < ActionView::Component::Base
+  def initialize(*)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,8 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  components:
+    component_with_translations:
+      title: Lorem ipsum
+      subtitle: More lorem ipsum
   hello: "Hello world"

--- a/spec/components/component_with_translations_spec.rb
+++ b/spec/components/component_with_translations_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe ComponentWithTranslations do
+  it "renders component with title from translations" do
+    result = render_inline(ComponentWithTranslations)
+
+    assert_includes result.text, I18n.t('components.component_with_translations.title')
+    assert_includes result.text, I18n.t('components.component_with_translations.subtitle')
+  end
+end


### PR DESCRIPTION
Issue https://github.com/github/actionview-component/issues/49

Fails with this error:
```
RuntimeError:
       Cannot use t(".title") shortcut because path is not available
```